### PR TITLE
Fix Issues with cloudformation stack

### DIFF
--- a/prerender-cloudfront.yaml
+++ b/prerender-cloudfront.yaml
@@ -5,10 +5,33 @@ Resources:
   WebBucket:
     Type: "AWS::S3::Bucket"
     Properties:
-      AccessControl: PublicRead
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: false
+        BlockPublicPolicy: false
+        IgnorePublicAcls: false
+        RestrictPublicBuckets: false
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: ObjectWriter
       WebsiteConfiguration:
         ErrorDocument: index.html
         IndexDocument: index.html
+
+  WebBucketPolicy:
+    Type: 'AWS::S3::BucketPolicy'
+    Properties:
+      Bucket: !Ref WebBucket
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal: '*'
+            Action: 's3:GetObject'
+            Resource: !Join
+              - ''
+              - - !GetAtt WebBucket.Arn
+                - '/*'
+
   LambdaEdgeExecutionRole:
     Type: AWS::IAM::Role
     Properties:
@@ -33,9 +56,11 @@ Resources:
                   - "logs:CreateLogGroup"
                   - "logs:CreateLogStream"
                   - "logs:PutLogEvents"
+
   SetPrerenderHeader:
     Type: "AWS::Lambda::Function"
     Properties:
+      FunctionName: !Sub "${AWS::StackName}-SetPrerenderHeader"
       Handler: "index.handler"
       Role:
         Fn::GetAtt:
@@ -64,16 +89,19 @@ Resources:
                 }
                 callback(null, request);
             };
-      Runtime: "nodejs14.x"
+      Runtime: "nodejs20.x"
+
   SetPrerenderHeaderVersion3:
     Type: "AWS::Lambda::Version"
     Properties:
       FunctionName:
         Ref: "SetPrerenderHeader"
       Description: "SetPrerenderHeader"
+
   RedirectToPrerender:
     Type: "AWS::Lambda::Function"
     Properties:
+      FunctionName: !Sub "${AWS::StackName}-RedirectToPrerender"
       Handler: "index.handler"
       Role:
         Fn::GetAtt:
@@ -102,13 +130,15 @@ Resources:
               }
               callback(null, request);
           };
-      Runtime: "nodejs14.x"
+      Runtime: "nodejs20.x"
+
   RedirectToPrerenderVersion1:
     Type: "AWS::Lambda::Version"
     Properties:
       FunctionName:
         Ref: "RedirectToPrerender"
       Description: "RedirectToPrerender"
+
   CloudFront:
     Type: "AWS::CloudFront::Distribution"
     Properties:
@@ -139,6 +169,7 @@ Resources:
         CustomErrorResponses:
           - ErrorCode: 404
             ResponseCode: 404
+            ResponsePagePath: /404.html
         # If you wish to respond with 200 even if the page is not existing
         # CustomErrorResponses:
         #   - ErrorCode: 404


### PR DESCRIPTION
I faced some issues in using the cloudformation template, the following changes fixed them on my end

Changes:

🔐 Updated S3 bucket configuration to use modern permission model with OwnershipControls and PublicAccessBlockConfiguration (ACL is failing)
🚀 Upgraded Lambda runtimes from nodejs14.x to nodejs20.x for both functions
🌐 Added 404 error page handling in CloudFront distribution

Technical Details:

- S3 changes address the "Bucket cannot have ACLs set with ObjectOwnership's BucketOwnerEnforced setting" error
- Lambda runtime updates resolve the deprecation of Node.js 14.x
- CloudFront error handling now properly configures both ResponseCode and ResponsePagePath

Deployment Note:
⚠️ Template must be deployed in us-east-1 region due to Lambda@Edge requirements.
