### PR TITLE
fix: ignore .woff2 and modern static-asset extensions

### DIFF
--- a/prerender-cloudfront.yaml
+++ b/prerender-cloudfront.yaml
@@ -54,7 +54,7 @@ Resources:
               if (user_agent && host) {
                 var prerender = /googlebot|adsbot\-google|Feedfetcher\-Google|bingbot|yandex|baiduspider|Facebot|facebookexternalhit|twitterbot|rogerbot|linkedinbot|embedly|quora link preview|showyoubot|outbrain|pinterest|slackbot|vkShare|W3C_Validator|redditbot|applebot|whatsapp|flipboard|tumblr|bitlybot|skypeuripreview|nuzzel|discordbot|google page speed|qwantify|pinterestbot|bitrix link preview|xing\-contenttabreceiver|chrome\-lighthouse|telegrambot|Perplexity|OAI-SearchBot|ChatGPT|GPTBot|ClaudeBot|Amazonbot|integration-test|iframely/i.test(user_agent[0].value);
                 prerender = prerender || /_escaped_fragment_/.test(request.querystring);
-                prerender = prerender && ! /\.(js|css|xml|less|png|jpg|jpeg|gif|pdf|doc|txt|ico|rss|zip|mp3|rar|exe|wmv|doc|avi|ppt|mpg|mpeg|tif|wav|mov|psd|ai|xls|mp4|m4a|swf|dat|dmg|iso|flv|m4v|torrent|ttf|woff|svg|eot)$/i.test(request.uri);
+                prerender = prerender && ! /\.(js|css|xml|less|png|jpg|jpeg|gif|pdf|doc|txt|ico|rss|zip|mp3|rar|exe|wmv|doc|avi|ppt|mpg|mpeg|tif|wav|mov|psd|ai|xls|mp4|m4a|swf|dat|dmg|iso|flv|m4v|torrent|ttf|woff|woff2|otf|svg|eot|webp|avif|webmanifest)$/i.test(request.uri);
                 if (prerender) {
                   headers['x-prerender-token'] = [{ key: 'X-Prerender-Token', value: '${PrerenderToken}'}];
                   headers['x-prerender-host'] = [{ key: 'X-Prerender-Host', value: host[0].value}];


### PR DESCRIPTION
## The bug

The inline Lambda@Edge function in `prerender-cloudfront.yaml` decides which requests to send to Prerender using a static-asset regex that is anchored with `$`:

```
/\.(js|css|...|ttf|woff|svg|eot)$/i
```

Because of the `$` anchor, `woff` does **not** cover `.woff2` and `avi` does **not** cover `.avif`. The list is also missing `otf`, `webp` and `webmanifest`. Bot requests for these static assets are therefore routed to `service.prerender.io` instead of being served from the origin/CDN.

## Live evidence

Verified live on prerender.io's own zone (which runs the equivalent Cloudflare-worker integration with the same gap): Googlebot UA requesting the site's own `inter-*.woff2` font gets a **504**, while a normal UA gets a **200**, and `.css`/`.js` correctly bypass. Same class of bug applies to this CloudFront integration.

## Canonical contract

This aligns the integration with the canonical static-asset ignore list, which now includes `.woff2 .otf .eot .webp .avif .webmanifest`: https://github.com/prerender/integration-contract/pull/1

## Changes

- `prerender-cloudfront.yaml`: extend the regex alternation with `woff2|otf|webp|avif|webmanifest` (`.eot` was already covered):

```
.../m4v|torrent|ttf|woff|woff2|otf|svg|eot|webp|avif|webmanifest)$/i
```

Single in-place edit on one line inside the `!Sub |` block scalar; indentation and YAML structure untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)